### PR TITLE
add GET /articles/search/:term

### DIFF
--- a/src/data/protocols/index.ts
+++ b/src/data/protocols/index.ts
@@ -1,2 +1,3 @@
 export * from './load-articles-repository'
 export * from './load-articles-by-category-repository'
+export * from './load-articles-by-term-repository'

--- a/src/data/protocols/load-articles-by-term-repository.ts
+++ b/src/data/protocols/load-articles-by-term-repository.ts
@@ -1,0 +1,9 @@
+import { Article as ArticleModel } from '@/domain/models'
+
+export interface LoadArticlesByTermRepository {
+  loadByTerm(term: string): Promise<LoadArticlesByTermRepository.Result>
+}
+
+export namespace LoadArticlesByTermRepository {
+  export type Result = ArticleModel[] | []
+}

--- a/src/data/usecases/db-load-articles-by-term.ts
+++ b/src/data/usecases/db-load-articles-by-term.ts
@@ -1,0 +1,13 @@
+import { LoadArticlesByTerm } from '@/domain/usecases'
+import { LoadArticlesByTermRepository } from '../protocols'
+
+export class DbLoadArticlesByTerm implements LoadArticlesByTerm {
+  constructor(
+    private readonly loadArticlesByTermRepository: LoadArticlesByTermRepository
+  ) {}
+
+  async loadByTerm(term: string): Promise<LoadArticlesByTerm.Result> {
+    const articles = await this.loadArticlesByTermRepository.loadByTerm(term)
+    return articles
+  }
+}

--- a/src/data/usecases/index.ts
+++ b/src/data/usecases/index.ts
@@ -1,2 +1,3 @@
 export * from './db-load-articles'
 export * from './db-load-articles-by-category'
+export * from './db-load-articles-by-term'

--- a/src/domain/usecases/index.ts
+++ b/src/domain/usecases/index.ts
@@ -1,2 +1,3 @@
 export * from './load-articles'
 export * from './load-articles-by-category'
+export * from './load-articles-by-term'

--- a/src/domain/usecases/load-articles-by-term.ts
+++ b/src/domain/usecases/load-articles-by-term.ts
@@ -1,0 +1,9 @@
+import { Article as ArticleModel } from '@/domain/models'
+
+export interface LoadArticlesByTerm {
+  loadByTerm: (category: string) => Promise<LoadArticlesByTerm.Result>
+}
+
+export namespace LoadArticlesByTerm {
+  export type Result = ArticleModel[] | []
+}

--- a/src/infra/db/mysql/repositories/article-mysql-repository.ts
+++ b/src/infra/db/mysql/repositories/article-mysql-repository.ts
@@ -1,11 +1,15 @@
 import {
   LoadArticlesByCategoryRepository,
+  LoadArticlesByTermRepository,
   LoadArticlesRepository,
 } from '@/data/protocols'
 import prisma from '@/infra/db/mysql/client'
 
 export class ArticleMysqlRepository
-  implements LoadArticlesRepository, LoadArticlesByCategoryRepository
+  implements
+    LoadArticlesRepository,
+    LoadArticlesByCategoryRepository,
+    LoadArticlesByTermRepository
 {
   async load(): Promise<LoadArticlesRepository.Result> {
     let articles = await prisma.article.findMany({
@@ -28,5 +32,9 @@ export class ArticleMysqlRepository
       },
     })
     return articles as unknown as LoadArticlesByCategoryRepository.Result
+  }
+
+  async loadByTerm(term: string): Promise<LoadArticlesByTermRepository.Result> {
+    return await Promise.resolve([])
   }
 }

--- a/src/infra/db/mysql/repositories/article-mysql-repository.ts
+++ b/src/infra/db/mysql/repositories/article-mysql-repository.ts
@@ -35,6 +35,24 @@ export class ArticleMysqlRepository
   }
 
   async loadByTerm(term: string): Promise<LoadArticlesByTermRepository.Result> {
-    return await Promise.resolve([])
+    return await prisma.article.findMany({
+      where: {
+        OR: [
+          {
+            title: {
+              contains: term,
+            },
+          },
+          {
+            content: {
+              contains: term,
+            },
+          },
+        ],
+      },
+      orderBy: {
+        date: 'desc',
+      },
+    })
   }
 }

--- a/src/main/factories/controllers/index.ts
+++ b/src/main/factories/controllers/index.ts
@@ -1,2 +1,3 @@
 export * from './load-articles-controller-factory'
 export * from './load-articles-by-category-controller-factory'
+export * from './load-articles-by-term-controller-factory'

--- a/src/main/factories/controllers/load-articles-by-term-controller-factory.ts
+++ b/src/main/factories/controllers/load-articles-by-term-controller-factory.ts
@@ -1,0 +1,7 @@
+import { LoadArticlesByTermController } from '@/presentation/controllers'
+import { Controller } from '@/presentation/protocols'
+import { makeDbLoadArticlesByTerm } from '../usecases'
+
+export const makeLoadArticlesByTermController = (): Controller => {
+  return new LoadArticlesByTermController(makeDbLoadArticlesByTerm())
+}

--- a/src/main/factories/usecases/db-load-articles-by-term-factory.ts
+++ b/src/main/factories/usecases/db-load-articles-by-term-factory.ts
@@ -1,0 +1,7 @@
+import { DbLoadArticlesByTerm } from '@/data/usecases'
+import { LoadArticlesByTerm } from '@/domain/usecases'
+import { ArticleMysqlRepository } from '@/infra/db/mysql/repositories/article-mysql-repository'
+
+export const makeDbLoadArticlesByTerm = (): LoadArticlesByTerm => {
+  return new DbLoadArticlesByTerm(new ArticleMysqlRepository())
+}

--- a/src/main/factories/usecases/index.ts
+++ b/src/main/factories/usecases/index.ts
@@ -1,2 +1,3 @@
 export * from './db-load-articles-factory'
 export * from './db-load-articles-by-category-factory'
+export * from './db-load-articles-by-term-factory'

--- a/src/main/routes/article-routes.ts
+++ b/src/main/routes/article-routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { adaptRoute } from '../adapters/express-route-adapter'
 import {
   makeLoadArticlesByCategoryController,
+  makeLoadArticlesByTermController,
   makeLoadArticlesController,
 } from '../factories/controllers'
 
@@ -10,5 +11,9 @@ export default (router: Router): void => {
   router.get(
     '/articles/:category',
     adaptRoute(makeLoadArticlesByCategoryController())
+  )
+  router.get(
+    '/articles/search/:term',
+    adaptRoute(makeLoadArticlesByTermController())
   )
 }

--- a/src/presentation/controllers/index.ts
+++ b/src/presentation/controllers/index.ts
@@ -1,2 +1,3 @@
 export * from './load-articles'
 export * from './load-articles-by-category'
+export * from './load-articles-by-term'

--- a/src/presentation/controllers/load-articles-by-term.ts
+++ b/src/presentation/controllers/load-articles-by-term.ts
@@ -1,0 +1,20 @@
+import { LoadArticlesByTerm } from '@/domain/usecases'
+import { Controller, HttpResponse } from '../protocols'
+
+export class LoadArticlesByTermController implements Controller {
+  constructor(private readonly loadArticlesByTerm: LoadArticlesByTerm) {}
+  async handle(
+    request: LoadArticlesByTermController.Request
+  ): Promise<LoadArticlesByTermController.Result> {
+    await this.loadArticlesByTerm.loadByTerm(request.term)
+    return null as any
+  }
+}
+
+export namespace LoadArticlesByTermController {
+  export type Request = {
+    term: string
+  }
+
+  export type Result = HttpResponse
+}

--- a/src/presentation/controllers/load-articles-by-term.ts
+++ b/src/presentation/controllers/load-articles-by-term.ts
@@ -1,6 +1,6 @@
 import { LoadArticlesByTerm } from '@/domain/usecases'
 import { Controller, HttpResponse } from '../protocols'
-import { serverError } from '../helpers/http-helper'
+import { ok, serverError } from '../helpers/http-helper'
 
 export class LoadArticlesByTermController implements Controller {
   constructor(private readonly loadArticlesByTerm: LoadArticlesByTerm) {}
@@ -8,8 +8,8 @@ export class LoadArticlesByTermController implements Controller {
     request: LoadArticlesByTermController.Request
   ): Promise<LoadArticlesByTermController.Result> {
     try {
-      await this.loadArticlesByTerm.loadByTerm(request.term)
-      return null as any
+      const articles = await this.loadArticlesByTerm.loadByTerm(request.term)
+      return ok(articles)
     } catch (error) {
       return serverError(error)
     }

--- a/src/presentation/controllers/load-articles-by-term.ts
+++ b/src/presentation/controllers/load-articles-by-term.ts
@@ -1,13 +1,18 @@
 import { LoadArticlesByTerm } from '@/domain/usecases'
 import { Controller, HttpResponse } from '../protocols'
+import { serverError } from '../helpers/http-helper'
 
 export class LoadArticlesByTermController implements Controller {
   constructor(private readonly loadArticlesByTerm: LoadArticlesByTerm) {}
   async handle(
     request: LoadArticlesByTermController.Request
   ): Promise<LoadArticlesByTermController.Result> {
-    await this.loadArticlesByTerm.loadByTerm(request.term)
-    return null as any
+    try {
+      await this.loadArticlesByTerm.loadByTerm(request.term)
+      return null as any
+    } catch (error) {
+      return serverError(error)
+    }
   }
 }
 

--- a/tests/data/mocks/articles-repository.ts
+++ b/tests/data/mocks/articles-repository.ts
@@ -1,10 +1,12 @@
 import {
   LoadArticlesByCategoryRepository,
+  LoadArticlesByTermRepository,
   LoadArticlesRepository,
 } from '@/data/protocols'
 import {
   mockArticles,
   mockArticlesWithSameCategory,
+  mockArticlesWithSameTerm,
 } from '@/tests/domain/mocks'
 
 export class LoadArticlesRepositorySpy implements LoadArticlesRepository {
@@ -20,5 +22,13 @@ export class LoadArticlesByCategoryRepositorySpy
     category: string
   ): Promise<LoadArticlesRepository.Result> {
     return await Promise.resolve(mockArticlesWithSameCategory())
+  }
+}
+
+export class LoadArticlesByTermRepositorySpy
+  implements LoadArticlesByTermRepository
+{
+  async loadByTerm(term: string): Promise<LoadArticlesRepository.Result> {
+    return await Promise.resolve(mockArticlesWithSameTerm())
   }
 }

--- a/tests/data/usecases/db-load-articles-by-term.spec.ts
+++ b/tests/data/usecases/db-load-articles-by-term.spec.ts
@@ -1,7 +1,8 @@
 import { DbLoadArticlesByTerm } from '@/data/usecases'
 import { LoadArticlesByTermRepository } from '@/data/protocols'
 import { LoadArticlesByTermRepositorySpy } from '../mocks/articles-repository'
-import { throwError } from '@/tests/domain/mocks'
+import { mockArticlesWithSameTerm, throwError } from '@/tests/domain/mocks'
+import Mockdate from 'mockdate'
 
 type SutTypes = {
   sut: DbLoadArticlesByTerm
@@ -18,6 +19,14 @@ const makeSut = (): SutTypes => {
 }
 
 describe('DbLoadArticlesByTerm', () => {
+  beforeEach(() => {
+    Mockdate.set(new Date())
+  })
+
+  afterEach(() => {
+    Mockdate.reset()
+  })
+
   it('should call loadArticlesByTermRepository with correct value', async () => {
     const { sut, loadArticlesByTermRepositorySpy } = makeSut()
     const loadByTermSpy = jest.spyOn(
@@ -45,5 +54,11 @@ describe('DbLoadArticlesByTerm', () => {
       .mockReturnValueOnce(Promise.resolve([]))
     const articles = await sut.loadByTerm('any value')
     expect(articles).toEqual([])
+  })
+
+  it('should return articles on succeeds', async () => {
+    const { sut } = makeSut()
+    const articles = await sut.loadByTerm('any value')
+    expect(articles).toEqual(mockArticlesWithSameTerm())
   })
 })

--- a/tests/data/usecases/db-load-articles-by-term.spec.ts
+++ b/tests/data/usecases/db-load-articles-by-term.spec.ts
@@ -1,0 +1,30 @@
+import { DbLoadArticlesByTerm } from '@/data/usecases'
+import { LoadArticlesByTermRepository } from '@/data/protocols'
+import { LoadArticlesByTermRepositorySpy } from '../mocks/articles-repository'
+
+type SutTypes = {
+  sut: DbLoadArticlesByTerm
+  loadArticlesByTermRepositorySpy: LoadArticlesByTermRepository
+}
+
+const makeSut = (): SutTypes => {
+  const loadArticlesByTermRepositorySpy = new LoadArticlesByTermRepositorySpy()
+  const sut = new DbLoadArticlesByTerm(loadArticlesByTermRepositorySpy)
+  return {
+    sut,
+    loadArticlesByTermRepositorySpy,
+  }
+}
+
+describe('DbLoadArticlesByTerm', () => {
+  it('should call loadArticlesByTermRepository with correct value', async () => {
+    const { sut, loadArticlesByTermRepositorySpy } = makeSut()
+    const loadByTermSpy = jest.spyOn(
+      loadArticlesByTermRepositorySpy,
+      'loadByTerm'
+    )
+    await sut.loadByTerm('any value')
+    expect(loadByTermSpy).toHaveBeenCalledWith('any value')
+    expect(loadByTermSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/data/usecases/db-load-articles-by-term.spec.ts
+++ b/tests/data/usecases/db-load-articles-by-term.spec.ts
@@ -37,4 +37,13 @@ describe('DbLoadArticlesByTerm', () => {
     const promise = sut.loadByTerm('any value')
     await expect(promise).rejects.toThrow()
   })
+
+  it('should return a empty array if loadArticlesByTermRepository returns a empty array', async () => {
+    const { sut, loadArticlesByTermRepositorySpy } = makeSut()
+    jest
+      .spyOn(loadArticlesByTermRepositorySpy, 'loadByTerm')
+      .mockReturnValueOnce(Promise.resolve([]))
+    const articles = await sut.loadByTerm('any value')
+    expect(articles).toEqual([])
+  })
 })

--- a/tests/data/usecases/db-load-articles-by-term.spec.ts
+++ b/tests/data/usecases/db-load-articles-by-term.spec.ts
@@ -1,6 +1,7 @@
 import { DbLoadArticlesByTerm } from '@/data/usecases'
 import { LoadArticlesByTermRepository } from '@/data/protocols'
 import { LoadArticlesByTermRepositorySpy } from '../mocks/articles-repository'
+import { throwError } from '@/tests/domain/mocks'
 
 type SutTypes = {
   sut: DbLoadArticlesByTerm
@@ -26,5 +27,14 @@ describe('DbLoadArticlesByTerm', () => {
     await sut.loadByTerm('any value')
     expect(loadByTermSpy).toHaveBeenCalledWith('any value')
     expect(loadByTermSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throws if loadArticlesByTermRepository throws', async () => {
+    const { sut, loadArticlesByTermRepositorySpy } = makeSut()
+    jest
+      .spyOn(loadArticlesByTermRepositorySpy, 'loadByTerm')
+      .mockImplementationOnce(throwError)
+    const promise = sut.loadByTerm('any value')
+    await expect(promise).rejects.toThrow()
   })
 })

--- a/tests/domain/mocks/mock-articles.ts
+++ b/tests/domain/mocks/mock-articles.ts
@@ -45,3 +45,22 @@ export const mockArticlesWithSameCategory = (): Article[] => [
     category: 'any_category',
   },
 ]
+
+export const mockArticlesWithSameTerm = (): Article[] => [
+  {
+    id: 1,
+    title: 'any value',
+    author: 'any_author',
+    content: 'any_value',
+    date: new Date(),
+    category: 'any_category',
+  },
+  {
+    id: 2,
+    title: 'any_value_2',
+    author: 'any_author_2',
+    content: 'any value',
+    date: new Date('2021-01-01'),
+    category: 'any_category_2',
+  },
+]

--- a/tests/infra/db/prisma/repositories/article-mysql-repository.spec.ts
+++ b/tests/infra/db/prisma/repositories/article-mysql-repository.spec.ts
@@ -94,5 +94,12 @@ describe('ArticleMysqlRepository', () => {
       const articles = await sut.loadByTerm('any_term')
       expect(articles).toEqual([])
     })
+
+    it('Should throws if prisma throws', async () => {
+      const sut = makeSut()
+      jest.spyOn(prisma.article, 'findMany').mockImplementationOnce(throwError)
+      const promise = sut.loadByTerm('any value')
+      await expect(promise).rejects.toThrow()
+    })
   })
 })

--- a/tests/infra/db/prisma/repositories/article-mysql-repository.spec.ts
+++ b/tests/infra/db/prisma/repositories/article-mysql-repository.spec.ts
@@ -87,4 +87,12 @@ describe('ArticleMysqlRepository', () => {
       await expect(promise).rejects.toThrow()
     })
   })
+
+  describe('loadByTerm', () => {
+    it('Should return a empty array if no articles are found', async () => {
+      const sut = makeSut()
+      const articles = await sut.loadByTerm('any_term')
+      expect(articles).toEqual([])
+    })
+  })
 })

--- a/tests/infra/db/prisma/repositories/article-mysql-repository.spec.ts
+++ b/tests/infra/db/prisma/repositories/article-mysql-repository.spec.ts
@@ -3,6 +3,7 @@ import {
   mockArticle,
   mockArticles,
   mockArticlesWithSameCategory,
+  mockArticlesWithSameTerm,
   throwError,
 } from '@/tests/domain/mocks'
 import Mockdate from 'mockdate'
@@ -64,7 +65,7 @@ describe('ArticleMysqlRepository', () => {
     })
   })
 
-  describe('loadByCategory', () => {
+  describe('loadByCategory()', () => {
     it('Should return a empty array if no articles are found', async () => {
       const sut = makeSut()
       const articles = await sut.loadByCategory('any_category')
@@ -88,7 +89,7 @@ describe('ArticleMysqlRepository', () => {
     })
   })
 
-  describe('loadByTerm', () => {
+  describe('loadByTerm()', () => {
     it('Should return a empty array if no articles are found', async () => {
       const sut = makeSut()
       const articles = await sut.loadByTerm('any_term')
@@ -100,6 +101,19 @@ describe('ArticleMysqlRepository', () => {
       jest.spyOn(prisma.article, 'findMany').mockImplementationOnce(throwError)
       const promise = sut.loadByTerm('any value')
       await expect(promise).rejects.toThrow()
+    })
+
+    it('Should return just only articles with same term provided', async () => {
+      const sut = makeSut()
+      await prisma.article.createMany({
+        data: mockArticlesWithSameTerm() as any,
+      })
+      await prisma.article.create({
+        data: Object.assign({}, mockArticle(), { id: 3 }) as any,
+      })
+      const articles = await sut.loadByTerm('any value')
+      expect(articles).toEqual(mockArticlesWithSameTerm())
+      expect(articles.length).toBe(2)
     })
   })
 })

--- a/tests/main/routes/article-routes.test.ts
+++ b/tests/main/routes/article-routes.test.ts
@@ -88,5 +88,19 @@ describe('Article Routes', () => {
           expect(res.body.length).toBe(0)
         })
     })
+
+    it('Should return 200 with an array with articles', async () => {
+      const article: any = mockArticle()
+      await prisma.article.create({
+        data: article,
+      })
+      article.date = article.date.toISOString()
+      await request(app)
+        .get(`/api/articles/search/${article.title}`)
+        .expect(200)
+        .then(res => {
+          expect(res.body).toEqual([article])
+        })
+    })
   })
 })

--- a/tests/main/routes/article-routes.test.ts
+++ b/tests/main/routes/article-routes.test.ts
@@ -77,4 +77,16 @@ describe('Article Routes', () => {
         })
     })
   })
+
+  describe('GET /articles/search/:term', () => {
+    it('Should return 200 with a empty array if no articles are found', async () => {
+      await request(app)
+        .get('/api/articles/search/any_term')
+        .expect(200)
+        .then(res => {
+          expect(Array.isArray(res.body)).toBe(true)
+          expect(res.body.length).toBe(0)
+        })
+    })
+  })
 })

--- a/tests/presentation/controllers/load-articles-by-term.spec.ts
+++ b/tests/presentation/controllers/load-articles-by-term.spec.ts
@@ -1,0 +1,31 @@
+import { LoadArticlesByTerm } from '@/domain/usecases'
+import { LoadArticlesByTermController } from '@/presentation/controllers'
+import { LoadArticlesByTermSpy } from '../mocks/load-articles'
+
+type SutTypes = {
+  sut: LoadArticlesByTermController
+  loadArticlesByTermSpy: LoadArticlesByTerm
+}
+
+const makeSut = (): SutTypes => {
+  const loadArticlesByTermSpy = new LoadArticlesByTermSpy()
+  const sut = new LoadArticlesByTermController(loadArticlesByTermSpy)
+  return {
+    sut,
+    loadArticlesByTermSpy,
+  }
+}
+
+const mockRequest = (): LoadArticlesByTermController.Request => ({
+  term: 'any value',
+})
+
+describe('LoadArticlesByTerm Controller', () => {
+  it('should call LoadArticlesByTerm with correct value', async () => {
+    const { sut, loadArticlesByTermSpy } = makeSut()
+    const loadByTermSpy = jest.spyOn(loadArticlesByTermSpy, 'loadByTerm')
+    await sut.handle(mockRequest())
+    expect(loadByTermSpy).toHaveBeenCalledWith(mockRequest().term)
+    expect(loadByTermSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/presentation/controllers/load-articles-by-term.spec.ts
+++ b/tests/presentation/controllers/load-articles-by-term.spec.ts
@@ -3,6 +3,7 @@ import { ok, serverError } from '@/presentation/helpers/http-helper'
 import { LoadArticlesByTermController } from '@/presentation/controllers'
 import { LoadArticlesByTermSpy } from '../mocks/load-articles'
 import { mockArticlesWithSameTerm, throwError } from '@/tests/domain/mocks'
+import Mockdate from 'mockdate'
 
 type SutTypes = {
   sut: LoadArticlesByTermController
@@ -23,6 +24,14 @@ const mockRequest = (): LoadArticlesByTermController.Request => ({
 })
 
 describe('LoadArticlesByTerm Controller', () => {
+  beforeEach(() => {
+    Mockdate.set(new Date())
+  })
+
+  afterEach(() => {
+    Mockdate.reset()
+  })
+
   it('should call LoadArticlesByTerm with correct value', async () => {
     const { sut, loadArticlesByTermSpy } = makeSut()
     const loadByTermSpy = jest.spyOn(loadArticlesByTermSpy, 'loadByTerm')

--- a/tests/presentation/controllers/load-articles-by-term.spec.ts
+++ b/tests/presentation/controllers/load-articles-by-term.spec.ts
@@ -1,6 +1,8 @@
 import { LoadArticlesByTerm } from '@/domain/usecases'
+import { serverError } from '@/presentation/helpers/http-helper'
 import { LoadArticlesByTermController } from '@/presentation/controllers'
 import { LoadArticlesByTermSpy } from '../mocks/load-articles'
+import { throwError } from '@/tests/domain/mocks'
 
 type SutTypes = {
   sut: LoadArticlesByTermController
@@ -27,5 +29,14 @@ describe('LoadArticlesByTerm Controller', () => {
     await sut.handle(mockRequest())
     expect(loadByTermSpy).toHaveBeenCalledWith(mockRequest().term)
     expect(loadByTermSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return ServerError if LoadArticlesByTerm throws', async () => {
+    const { sut, loadArticlesByTermSpy } = makeSut()
+    jest
+      .spyOn(loadArticlesByTermSpy, 'loadByTerm')
+      .mockImplementationOnce(throwError)
+    const articles = await sut.handle(mockRequest())
+    expect(articles).toEqual(serverError(new Error().stack as string))
   })
 })

--- a/tests/presentation/controllers/load-articles-by-term.spec.ts
+++ b/tests/presentation/controllers/load-articles-by-term.spec.ts
@@ -1,8 +1,8 @@
 import { LoadArticlesByTerm } from '@/domain/usecases'
-import { serverError } from '@/presentation/helpers/http-helper'
+import { ok, serverError } from '@/presentation/helpers/http-helper'
 import { LoadArticlesByTermController } from '@/presentation/controllers'
 import { LoadArticlesByTermSpy } from '../mocks/load-articles'
-import { throwError } from '@/tests/domain/mocks'
+import { mockArticlesWithSameTerm, throwError } from '@/tests/domain/mocks'
 
 type SutTypes = {
   sut: LoadArticlesByTermController
@@ -38,5 +38,11 @@ describe('LoadArticlesByTerm Controller', () => {
       .mockImplementationOnce(throwError)
     const articles = await sut.handle(mockRequest())
     expect(articles).toEqual(serverError(new Error().stack as string))
+  })
+
+  it('should return Articles with same term on succeeds', async () => {
+    const { sut } = makeSut()
+    const articles = await sut.handle(mockRequest())
+    expect(articles).toEqual(ok(mockArticlesWithSameTerm()))
   })
 })

--- a/tests/presentation/mocks/load-articles.ts
+++ b/tests/presentation/mocks/load-articles.ts
@@ -1,7 +1,12 @@
-import { LoadArticles, LoadArticlesByCategory } from '@/domain/usecases'
+import {
+  LoadArticles,
+  LoadArticlesByCategory,
+  LoadArticlesByTerm,
+} from '@/domain/usecases'
 import {
   mockArticles,
   mockArticlesWithSameCategory,
+  mockArticlesWithSameTerm,
 } from '@/tests/domain/mocks/mock-articles'
 
 export class LoadArticlesSpy implements LoadArticles {
@@ -15,5 +20,11 @@ export class LoadArticlesByCategorySpy implements LoadArticlesByCategory {
     category: string
   ): Promise<LoadArticlesByCategory.Result> {
     return await Promise.resolve(mockArticlesWithSameCategory())
+  }
+}
+
+export class LoadArticlesByTermSpy implements LoadArticlesByTerm {
+  async loadByTerm(term: string): Promise<LoadArticlesByTerm.Result> {
+    return await Promise.resolve(mockArticlesWithSameTerm())
   }
 }


### PR DESCRIPTION
- feat: ensure LoadArticlesByTermController call LoadArticlesByTerm with correct value
- feat: ensure LoadArticlesByTermController return serverError if LoadArticlesByTerm throws
- feat: ensure LoadArticlesByTermController return Articles with same term on succeeds
- feat: ensure DbLoadArticlesByTerm call loadArticlesByTermRepository with correct value
- fix: ensure DbLoadArticlesByTerm throws if loadArticlesByTermRepository throws
- feat: ensure DbLoadArticlesByTerm return a empty array if no articles are found
- feat: ensure DbLoadArticlesByTerm returns articles on succeeds
- feat: ensure loadByTerm returns a empty array if no articles are found
- feat: ensure loadByTerm throws if prisma thorws
- test: ensure loadByTerm return just only articles with same term provided
- feat: ensure GET /articles/search/:term return 200 with a empty array if no articles are found
- feat: ensure GET /articles/search/:term return 200 with an array with articles
